### PR TITLE
Add logger for when the response body isn't JSON decodable

### DIFF
--- a/pytest_chalice.py
+++ b/pytest_chalice.py
@@ -3,10 +3,17 @@
 import pytest
 
 import json
+from logging import getLogger
 import re
 
 from chalice.config import Config
 from chalice.local import LocalGateway
+
+
+logger = getLogger(__name__)
+
+# Python 3.4 or older don't have JSONDecodeError within json module
+JSONDecodeError = json.JSONDecodeError if hasattr(json, 'JSONDecodeError') else ValueError  # type: ignore
 
 
 class InternalLocalGateway(LocalGateway):
@@ -33,8 +40,8 @@ class ResponseHandler:
 
         try:
             self.values['json'] = json.loads(self.values['body'])
-        except json.JSONDecodeError:
-            pass
+        except JSONDecodeError:
+            logger.info('Response body is NOT JSON decodable: {}'.format(self.values['body']))
 
     def __getattr__(self, key):
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,4 +20,8 @@ def app():
         context = app.current_request.context
         return {'context': context}
 
+    @app.route('/string')
+    def string():
+        return 'Foo'
+
     yield app

--- a/tests/test_chalice.py
+++ b/tests/test_chalice.py
@@ -16,6 +16,10 @@ class TestRequest:
         with pytest.raises(AttributeError, match=r' object has no attribute '):
             client.invalid_method('/')
 
+    def test_string_response_dont_have_json_attribute(self, client):
+        response = client.get('/string')
+        assert not hasattr(response, 'json')
+
 
 class TestCustomContext:
     def test_check_default_context(self, client):


### PR DESCRIPTION
As title

And, I've not noticed that `python 3.4` or older don't have `JSONDecodeError` in `json` module, so also added a handler and a test for that